### PR TITLE
Remove badge issue on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# is-whitespace [![NPM version](https://badge.fury.io/js/is-whitespace.svg)](http://badge.fury.io/js/is-whitespace)  [![Build Status](https://travis-ci.org/jonschlinkert/is-whitespace.svg)](https://travis-ci.org/jonschlinkert/is-whitespace)
+# is-whitespace [![NPM version](https://badge.fury.io/js/is-whitespace.svg)](http://badge.fury.io/js/is-whitespace)
 
 > Returns true if the value passed is all whitespace.
 


### PR DESCRIPTION
This PR is an excuse!

---

My main point is: Could you publish the version `0.3.1` on npm ?

On the version published, we can see: 
```
"license": {
  "type":"MIT",
  "url": "https://github.com/jonschlinkert/is-whitespace/blob/master/LICENSE"
},
```
In the package it's: 
```
"license": "MIT"
```

And it's nicer for reporting tools:
![image](https://github.com/user-attachments/assets/6491ae60-7cf8-42c1-92e2-18dfe804f81b)

Thank you